### PR TITLE
Feature/prometheus metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'json', '~> 2.1'
 gem 'rest-client', '~> 2.0'
 
 gem 'sentry-raven', '~> 2'
+gem 'prometheus-client', '~> 0.8.0'
 
 group :test do
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,10 +29,13 @@ GEM
     mime-types-data (3.2016.0521)
     multipart-post (2.0.0)
     netrc (0.11.0)
+    prometheus-client (0.8.0)
+      quantile (~> 0.2.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (3.0.1)
+    quantile (0.2.1)
     rack (1.6.9)
     rack-protection (1.5.5)
       rack
@@ -98,6 +101,7 @@ PLATFORMS
 DEPENDENCIES
   coveralls
   json (~> 2.1)
+  prometheus-client (~> 0.8.0)
   pry
   rack-protection (~> 1.5.5)
   rack-test (~> 0.8.2)

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,8 @@
 # config.ru
+require 'rack'
 require 'sinatra/base'
+require 'prometheus/middleware/collector'
+require 'prometheus/middleware/exporter'
 require 'raven'
 
 # pull in the helpers and controllers
@@ -7,11 +10,26 @@ Dir.glob('./app/{helpers,controllers}/*.rb').each { |file| require file }
 
 # map the controllers to routes
 #map('/')      { run ResourceController }
-run ResourceController 
+run ResourceController
 map('/docs')   { run DocsController } if ENV['RACK_ENV'] == 'development' || ENV['RACK_ENV'] == 'test'
 
 Raven.configure do |config|
   config.server = ENV['SENTRY_DSN']
 end
+
+use Rack::Deflater
+# Run prometheus middleware to collect default metrics
+use Prometheus::Middleware::Collector, metrics_prefix: ENV['PROMETHEUS_METRICS_PREFIX'], counter_label_builder: -> (env, code) {
+  {
+    code:         code,
+    method:       env['REQUEST_METHOD'].downcase,
+    host:         env['HTTP_HOST'].to_s,
+    path:         env['PATH_INFO'],
+    querystring:  env['QUERY_STRING']
+  }
+}
+# Run prometheus exporter to have a /metrics endpoint that can be scraped
+# The endpoint will only be available to prometheus
+use Prometheus::Middleware::Exporter
 
 use Raven::Rack


### PR DESCRIPTION
@ericgriffis This is all that should have to happen to implement out of the box metrics.

These are all worth reading to understand what's happening:

https://github.com/prometheus/client_ruby
https://github.com/prometheus/client_ruby/tree/master/examples/rack
https://github.com/prometheus/client_ruby/blob/master/lib/prometheus/middleware/collector.rb

Running the application locally should give you an http://localhost:9292/metrics endpoint where you can see what prometheus will be consuming. 